### PR TITLE
Add react and react-dom to dev dependencies. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     "sass": "^1.86.0",
     "sass-loader": "^16.0.5",
     "storybook": "^8.6.8",
-    "style-loader": "^4.0.0"
+    "style-loader": "^4.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "peerDependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
In my initial configuration, I setup react and react-dom as peer dependencies but forgot to include them as dev dependencies. I wasn't seeing an issue because storybook includes react and react-dom as dev dependencies. 

This PR adds react and react-dom to dev dependencies. 

Also, in the previous PR, I mentioned an issue with NPM link that I was looking into. Since `npm link` creates a link to the entire library's repo, the node_modules includes the react and react-dom that were installed as dev dependencies. This causes the invalid hook call error when there are two sources of React. So adding the alias fixes the issue when using `npm link`. I just wanted to add that for completion.