### PR TITLE
Add handle bar to resize containers.

### DIFF
--- a/src/components/LayoutManager/Components/Column/Column.jsx
+++ b/src/components/LayoutManager/Components/Column/Column.jsx
@@ -11,9 +11,10 @@ import "./Column.scss";
  * in the LDF file.
  * 
  * @param {Object} container JSON object containing information about the container and its children.
+ * @param {Boolean} renderHandle Flag to indicate if a handle should be rendered.
  * @returns 
  */
-export const Column = ({container}) => {
+export const Column = ({container, renderHandle}) => {
 
     const [columnStyle, setColumnStyle] = useState({});
     const [childDivs, setChildDivs] = useState(null)
@@ -49,6 +50,7 @@ export const Column = ({container}) => {
 
     return (
         <div style={columnStyle}> 
+            {renderHandle && <div className="handleBarHorizontal"></div>}
             <div className="contentHorizontal">
                 {childDivs}
             </div>

--- a/src/components/LayoutManager/Components/Column/Column.jsx
+++ b/src/components/LayoutManager/Components/Column/Column.jsx
@@ -39,8 +39,8 @@ export const Column = ({container, renderHandle}) => {
 
     useEffect(() => {
         if (container) {
-            // Once a container is loaded, set the style of the 
-            // column and load the child divs.
+            // Once column is loaded, set the style and
+            // load the child divs.
             setColumnStyle({
                 "height": "100%",
                 "width": container.width + "%",
@@ -85,8 +85,8 @@ export const Column = ({container, renderHandle}) => {
     /**
      * This function is called when the mouse is being dragged and 
      * it uses the delta from the starting down point to calculate
-     * the new heights. If it is within the bounds, it sets the new
-     * height. It sets the height as a percentage so the relative 
+     * the new widths. If it is within the bounds, it sets the new
+     * widths. It sets the width as a percentage so the relative 
      * sizes are respected if a parent up the hierarchy is moved.
      * @param {Event} e 
      * @returns 
@@ -103,7 +103,7 @@ export const Column = ({container, renderHandle}) => {
         const newPreWidth = startInfo.cont1Width - delta;
         const newPostWidth = startInfo.cont2Width + delta;
 
-        // If within bounds, assign new height as a percentage of the container's full height
+        // If within bounds, assign new width as a percentage of the container's full width
         if (newPreWidth > MIN_CONTAINER_WIDTH && newPostWidth > MIN_CONTAINER_WIDTH) {
             startInfo.cont1.style.width = (newPreWidth/startInfo.contWidth)*100 + "%";
             startInfo.cont2.style.width = (newPostWidth/startInfo.contWidth)*100 + "%";

--- a/src/components/LayoutManager/Components/Container/Container.jsx
+++ b/src/components/LayoutManager/Components/Container/Container.jsx
@@ -26,13 +26,16 @@ export const Container = ({layout}) => {
         const _childDivs = [];
 
         layout.children.forEach((child,index) => {
+            // If index > 0, then we include the handle bar to allow
+            // the siblings to be resized.
+            const showHandle = index > 0;
 
             if (layout.childType === "row") {
-                _childDivs.push(<Row key={index} container={child}/>)
+                _childDivs.push(<Row key={index} container={child} renderHandle={showHandle}/>)
             } 
             
             if (layout.childType === "column") {
-                _childDivs.push(<Column key={index} container={child}/>);
+                _childDivs.push(<Column key={index} container={child} renderHandle={showHandle}/>);
             }
         });
 

--- a/src/components/LayoutManager/Components/PlaceHolder/PlaceHolder.scss
+++ b/src/components/LayoutManager/Components/PlaceHolder/PlaceHolder.scss
@@ -1,7 +1,0 @@
-.hoverDiv {
-    background-color: #111111;
-}
-
-.hoverDiv:hover {
-    background-color: #222222;
-}

--- a/src/components/LayoutManager/Components/Row/Row.jsx
+++ b/src/components/LayoutManager/Components/Row/Row.jsx
@@ -53,6 +53,10 @@ export const Row = ({container, renderHandle}) => {
     }, [container])
 
 
+    /* TODO: The row and column containers have a lot of shared logic, 
+    I should probably optimize that.*/
+
+
     /**
      * This function is called on a mouse down event. It saves relevant
      * information to the dragStartInfo ref so that it can be accsessed
@@ -72,8 +76,8 @@ export const Row = ({container, renderHandle}) => {
      * 
      * In the image, I drew the handle inside Cont2 and Cont3 because that
      * is where it is rendered. So to get to Cont2, you would get the parent
-     * of the handle and the parents previous sibling. To get the full container
-     * width, you would get the parent elements parent element.
+     * of the handle and the parents previous sibling would be Cont1. To get the 
+     * full container width, you would get the parent elements parent element.
      * @param {Event} e 
      */
     const handleMouseDown = (e) => {

--- a/src/components/LayoutManager/Components/Row/Row.jsx
+++ b/src/components/LayoutManager/Components/Row/Row.jsx
@@ -59,8 +59,8 @@ export const Row = ({container, renderHandle}) => {
      * during the drag event to calculate and assign the new values. 
      * 
      * 
-     * I'm using a vertical handle bar example because its easier to draw but 
-     * it works the same way for horizontal handle bars.
+     * I'm using a horizontal handle bar example because its easier to draw but 
+     * it works the same way for vertical handle bars.
      * 
      * [              container               ]
      * [ Cont 1 ][<handle>Cont2][<handle>Cont3]

--- a/src/components/LayoutManager/Components/Row/Row.jsx
+++ b/src/components/LayoutManager/Components/Row/Row.jsx
@@ -78,6 +78,17 @@ export const Row = ({container, renderHandle}) => {
      * is where it is rendered. So to get to Cont2, you would get the parent
      * of the handle and the parents previous sibling would be Cont1. To get the 
      * full container width, you would get the parent elements parent element.
+     * 
+     * In the coming updates, a callback function will be used to ask the parent
+     * to approve the new values. For example, it can decide to collapse one of the
+     * containers into a side menu. It can set the min and max values. With this
+     * structure, we are able to centralize the logic for how each container
+     * manages its children.
+     * 
+     * When a parent container is resized, all the children will get resized at
+     * the same time. So all the child elements in the DOM tree should execute their
+     * logic to react to the new values.
+     * 
      * @param {Event} e 
      */
     const handleMouseDown = (e) => {

--- a/src/components/LayoutManager/Components/Row/Row.jsx
+++ b/src/components/LayoutManager/Components/Row/Row.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import PropTypes from 'prop-types';
 import { Container } from "../Container/Container";
 import { PlaceHolder } from "../PlaceHolder/PlaceHolder";
@@ -16,8 +16,12 @@ import "./Row.scss";
  */
 export const Row = ({container, renderHandle}) => {
 
+    const MIN_CONTAINER_HEIGHT = 50;
+
     const [rowStyle, setRowStyle] = useState({});
     const [childDivs, setChildDivs] = useState(null)
+
+    const dragStartInfo = useRef()
     
     /**
      * This function loads the children into a container if they
@@ -35,8 +39,8 @@ export const Row = ({container, renderHandle}) => {
 
     useEffect(() => {
         if (container) {
-            // Once a container is loaded, set the style of the 
-            // row and load the child divs.
+            // Once row is loaded, set the style and
+            // load the child divs.
             setRowStyle({
                 "width": "100%",
                 "height": container.height + "%",
@@ -48,11 +52,88 @@ export const Row = ({container, renderHandle}) => {
         }
     }, [container])
 
+
+    /**
+     * This function is called on a mouse down event. It saves relevant
+     * information to the dragStartInfo ref so that it can be accsessed
+     * during the drag event to calculate and assign the new values. 
+     * 
+     * 
+     * I'm using a vertical handle bar example because its easier to draw but 
+     * it works the same way for horizontal handle bars.
+     * 
+     * [              container               ]
+     * [ Cont 1 ][<handle>Cont2][<handle>Cont3]
+     * 
+     * In the image above, the container row is the full width and when
+     * a handle is selected for Cont1 and Cont2 for example, the handle 
+     * (which is the target div of the event that fired) is used to find
+     * Cont1 and Cont2 using the DOM tree. 
+     * 
+     * In the image, I drew the handle inside Cont2 and Cont3 because that
+     * is where it is rendered. So to get to Cont2, you would get the parent
+     * of the handle and the parents previous sibling. To get the full container
+     * width, you would get the parent elements parent element.
+     * @param {Event} e 
+     */
+    const handleMouseDown = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        document.addEventListener("mousemove", handleMouseMove);
+        document.addEventListener("mouseup", handleMouseUp);
+
+        dragStartInfo.current = {
+            "downValueY": e.clientY,
+            "cont1": e.target.parentElement,
+            "cont2": e.target.parentElement.previousElementSibling,
+            "contHeight": e.target.parentElement.parentElement.getBoundingClientRect().height,
+            "cont1Height": e.target.parentElement.getBoundingClientRect().height,
+            "cont2Height": e.target.parentElement.previousElementSibling.getBoundingClientRect().height
+        }
+    }
+
+    /**
+     * This function is called when the mouse is being dragged and 
+     * it uses the delta from the starting down point to calculate
+     * the new heights. If it is within the bounds, it sets the new
+     * height. It sets the height as a percentage so the relative 
+     * sizes are respected if a parent up the hierarchy is moved.
+     * @param {Event} e 
+     * @returns 
+     */
+    const handleMouseMove = (e) => {
+        if (!dragStartInfo.current) return;
+        e.preventDefault();
+        e.stopPropagation();
+
+        const startInfo = dragStartInfo.current;
+
+        // Use delta from starting down point to calculate new heights
+        const delta = e.clientY - startInfo.downValueY;
+        const newPreHeight = startInfo.cont1Height - delta;
+        const newPostHeight = startInfo.cont2Height + delta;
+
+        // If within bounds, assign new height as a percentage of the container's full height
+        if (newPreHeight > MIN_CONTAINER_HEIGHT && newPostHeight > MIN_CONTAINER_HEIGHT) {
+            startInfo.cont1.style.height = (newPreHeight/startInfo.contHeight)*100 + "%";
+            startInfo.cont2.style.height = (newPostHeight/startInfo.contHeight)*100 + "%";
+        }
+    }
+
+    /**
+     * Perform cleanup after drag event has finished.
+     * @param {Event} e 
+     */
+    const handleMouseUp = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+    }
+
     return (
         <div style={rowStyle}> 
-            {renderHandle && 
-                <div className="handleBarVertical"></div>
-            }
+            {renderHandle && <div onMouseDown={handleMouseDown} className="handleBarVertical"></div>}
             <div className="contentVertical">
                 {childDivs}
             </div>

--- a/src/components/LayoutManager/Components/Row/Row.jsx
+++ b/src/components/LayoutManager/Components/Row/Row.jsx
@@ -11,9 +11,10 @@ import "./Row.scss";
  * specified in the LDF file.
  * 
  * @param {Object} container JSON object containing information about the container and its children.
+ * @param {Boolean} renderHandle Flag to indicate if a handle should be rendered.
  * @returns 
  */
-export const Row = ({container}) => {
+export const Row = ({container, renderHandle}) => {
 
     const [rowStyle, setRowStyle] = useState({});
     const [childDivs, setChildDivs] = useState(null)
@@ -49,6 +50,9 @@ export const Row = ({container}) => {
 
     return (
         <div style={rowStyle}> 
+            {renderHandle && 
+                <div className="handleBarVertical"></div>
+            }
             <div className="contentVertical">
                 {childDivs}
             </div>
@@ -57,5 +61,6 @@ export const Row = ({container}) => {
 }
 
 Row.propTypes = {
-    container: PropTypes.object
+    container: PropTypes.object,
+    renderHandle: PropTypes.bool
 }

--- a/src/stories/LayoutManager.stories.js
+++ b/src/stories/LayoutManager.stories.js
@@ -9,7 +9,7 @@ import denseLayoutJSON from "./data/denseLayout.json"
 import vsCodeLayoutJSON from "./data/vsCodeLayout.json"
 
 export default {
-    title: 'LayoutManager', 
+    title: 'Layout With Resizing', 
     component: LayoutManager,
     argTypes: {
         ldf: {


### PR DESCRIPTION
This PR adds a feature to generate handle bars between adjacent sibling containers. The handle bar identifies the adjacent elements using the DOM tree and uses the delta from the drag event to calculate the new values (widths and heights) before validating and applying them.

## Background

In the previous PR, logic was added to recursively process the LDF file by creating the parent containers and containers for children of the parent container. When rendering child containers, this PR adds a handle bar between the siblings. 

Note: The handle bar inside the second sibling (see green and yellow handler bar) because this simplifies the layout and ensures that the relative sizes are respected during resizing.

<img width="603" height="214" alt="image" src="https://github.com/user-attachments/assets/d5eb1924-187e-4c2c-accd-7b4b104ae0aa" />

For example, in the image above, if the green handle bar was used to create a drag event, the following steps would occur on mouse down:
- The initial down position (x or y) is saved to the startDragInfo ref 
- The handle bar is the target ref of the mouse down event
- Find child2 by getting the parent of the handle bar
- Find child1 by getting the previous sibling of child 2
- Find the parent container by getting the parent of child1 or child 2
- Save the children, parent and initial state of the container values (width or height) to startDragInfo ref
- Start mousemove and mouseup listeners to process drag event

At this point, when the mouse is dragged, the delta is calculated from the initial down position. The new heights and widths are calculated and validated before applying them to the children. On mouse up, the listeners are destroyed and the dragInfo ref is cleared.

In the future, the new heights or widths will be sent to the parent container for validation. This is because the parent container can execute custom logic to collapse containers into a side menu when they reach minimum width or it can enforce max and min widths etc. 

When a parent container is resized, all the children below it in the DOM tree will be resized (not just the first level), so they should react to the new values. I will address that in another PR. I also plan to add functionality to programmatically be able to modify different parts of the UI by allowing parent containers to register themselves. So if the user wants to collapse a container called "side menu", they should be able to do it. 

Note: 
I am looking into whether relying on the DOM tree to find the sibling containers is a robust solution to this problem. Since I am the one creating the containers, I felt confident in using this approach. I guess if someone were to inject elements into the part of the DOM tree that the layout manager generated, it could break the logic (or be used in a malicious way). Alternatively, when searching for the parents or siblings, I could tag the elements created by the layout manager and only load those. I will think about this some more.

## Validation Performed
- Validated that all the containers were resizable in the storybook variants and that the minimum size was respected. 
- Built the library, imported it into the playground, loaded a layout and verified that all the containers were resizable. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added draggable handle bars to columns and rows, allowing users to resize adjacent containers interactively.
  * Resizing handles are now visible between layout sections (except for the first container in each group).

* **Style**
  * Removed hover effect styling from placeholder elements for a cleaner appearance.

* **Documentation**
  * Updated Storybook display name to "Layout With Resizing" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->