### PR TITLE
Enhance the handle styling by increasing its size on hover to improve usability and visual feedback.

### DIFF
--- a/src/components/LayoutManager/Components/Container/Container.jsx
+++ b/src/components/LayoutManager/Components/Container/Container.jsx
@@ -22,7 +22,7 @@ export const Container = ({layout}) => {
     const containerRef = useRef();
     const childRefs = useRef([]);
 
-    const HANDLE_SIZE_PX = 2;
+    const HANDLE_SIZE_PX = 1;
    
     /**
      * This function loops through the children, sets the style and 

--- a/src/components/LayoutManager/Components/HandleBar/HandleBar.jsx
+++ b/src/components/LayoutManager/Components/HandleBar/HandleBar.jsx
@@ -31,17 +31,22 @@ export const HandleBar = React.forwardRef(({orientation, getSiblings, index}, re
 
         const [parentRef, sibling1, sibling2] = getSiblings(index);
 
-        let downKey, propKey;
+        let downKey, propKey, hoverClass;
         if (orientation === "row") {
             downKey = "clientY";
             propKey = "height";
+            hoverClass = "handleBarHorizontalHover";
         } else if (orientation === "column"){
             downKey = "clientX";
             propKey = "width";
+            hoverClass = "handleBarVerticalHover";
         }
+        
+        handle.current.classList.add(hoverClass);   
 
         dragStartInfo.current = {
             "downValueY": e[downKey],
+            "hoverClass": hoverClass,
             "downKey": downKey,
             "propKey": propKey,
             "sibling1": sibling1,
@@ -90,6 +95,7 @@ export const HandleBar = React.forwardRef(({orientation, getSiblings, index}, re
         e.stopPropagation();
         document.removeEventListener("mousemove", handleMouseMove);
         document.removeEventListener("mouseup", handleMouseUp);
+        handle.current.classList.remove(dragStartInfo.current.hoverClass);  
         dragStartInfo.current = null;        
     }
 

--- a/src/components/LayoutManager/Components/HandleBar/HandleBar.scss
+++ b/src/components/LayoutManager/Components/HandleBar/HandleBar.scss
@@ -1,5 +1,5 @@
 $handle-bar-color: #414141;
-$handle-bar-size: 2px;
+$handle-bar-size: 1px;
 $handle-bar-size-expanded: 5px;
 $handle-bar-hover-color: #007acc;
 

--- a/src/components/LayoutManager/Components/HandleBar/HandleBar.scss
+++ b/src/components/LayoutManager/Components/HandleBar/HandleBar.scss
@@ -19,7 +19,7 @@ $handle-bar-hover-color: #007acc;
     left:0;
     right:0;
     transform: translateY(-50%);
-    transition: all 0.3s ease;
+    transition: all 0.2s ease;
 }
 
 // Update the height and let it animate

--- a/src/components/LayoutManager/Components/HandleBar/HandleBar.scss
+++ b/src/components/LayoutManager/Components/HandleBar/HandleBar.scss
@@ -19,13 +19,26 @@ $handle-bar-hover-color: #007acc;
     left:0;
     right:0;
     transform: translateY(-50%);
+    transition: all 0.3s ease;
 }
 
 // Update the height and let it animate
 .handleBarHorizontal:hover {
     background-color: $handle-bar-hover-color;
     cursor: ns-resize; 
+    height: $handle-bar-size-expanded;
+    z-index: 10;
 }
+
+// Set by the component so hover is active even
+// when mouse isn't over handle during drag
+.handleBarHorizontalHover {
+    background-color: $handle-bar-hover-color;
+    cursor: ns-resize; 
+    height: $handle-bar-size-expanded;
+    z-index: 10;
+}
+
 
 // See horizontal style comments, they are the same for vertical
 .handleBarVerticalContainer {
@@ -43,9 +56,19 @@ $handle-bar-hover-color: #007acc;
     left: 50%;
     bottom: 0;
     transform: translateX(-50%);
+    transition: all 0.3s ease;
 }
 
 .handleBarVertical:hover {
     background-color: $handle-bar-hover-color;
     cursor: ew-resize; 
+    width: $handle-bar-size-expanded;
+    z-index: 10;
+}
+
+.handleBarVerticalHover {
+    background-color: $handle-bar-hover-color;
+    cursor: ew-resize; 
+    width: $handle-bar-size-expanded;
+    z-index: 10;
 }

--- a/src/components/LayoutManager/Components/LazyLoader/LazyLoader.scss
+++ b/src/components/LayoutManager/Components/LazyLoader/LazyLoader.scss
@@ -1,7 +1,7 @@
 .lazyContainer {
     position: absolute;
-    top: 2px;
-    bottom: 2px;
-    left: 2px;
-    right: 2px;
+    top: 0px;
+    bottom: 0px;
+    left: 0px;
+    right: 0px;
 }


### PR DESCRIPTION
This PR enhances the style of the handle bar to increase its size on hover. This improves usability and visual feedback. 

Please see storybook for a demo:
https://vishalpalaniappan.github.io/ui-layout-manager/

The handle bars now have a width and height of 1px. When hovering over them, it increases to 5 pixels and it does so using a transition while also changing the color. 

The padding around the rendered component has been decreased for a more compact appearance. 

<img width="1611" height="770" alt="image" src="https://github.com/user-attachments/assets/91760902-3992-4f3f-afb3-cf479a0f69c8" />

## Validation Performed
- Verified that resizing behavior worked as expected in storybook.
- Verified that resizing behavior worked as expected in the playground after building library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reduced handle bar thickness for a sleeker appearance.
  * Enhanced handle bar with smooth transition animations and improved hover effects during drag operations.
  * Updated handle bar hover feedback to remain active while dragging.
  * Adjusted lazy container layout to stretch fully to the edges, removing previous margins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->