### PR TITLE
Allow layout nodes to register references to themselves with central controller and use workers to process layout logic. 

### DIFF
--- a/src/components/LayoutManager/LayoutManager.jsx
+++ b/src/components/LayoutManager/LayoutManager.jsx
@@ -14,7 +14,10 @@ import "./LayoutManager.scss";
  * @return {JSX}
  */
 export const LayoutManager = ({ldf, registry}) => {
-    const [rootContainer, setRootContainer] = useState(null);  
+    const [rootContainer, setRootContainer] = useState(null); 
+    
+    // TODO: Add context to allow children to register references to themselves
+    // TODO: Add worker to manage layout logic
 
     useEffect(() => {
         if (ldf) {


### PR DESCRIPTION
This PR starts the process of implementing custom layout resize logic in an efficient way. 

I went through a few different approaches for how to do this and settled on this efficient approach: 
- Each node in the layout tree registers a reference to its root container with a central controller
- When a resize event happens, the siblings that were resized pass their new sizes to a central controller
- These new sizes are passed to a worker where it evaluates the sizes of all the child nodes in the tree
- The worker returns updated sizes and styles for each of the children
- The central controller then updates the style of the containers

The benefit of using this approach is:
- we can resize the container without triggering a re-render in react by updating the component's style directly using the ref
- the worker manages all the resize logic (this will absorb the logic implemented in PR #15) in a separate thread
- the layout resizing can be denounced
- the layout resizing can be immediately cached to local storage