### PR TITLE
Re-calculate layout when root container size changes using worker and update DOM using container API.

### DIFF
--- a/src/components/LayoutManager/Components/RootContainer/RootContainer.jsx
+++ b/src/components/LayoutManager/Components/RootContainer/RootContainer.jsx
@@ -24,6 +24,15 @@ export const RootContainer = () => {
     const rootContainerAPI = useRef({});
     rootContainerAPI.current = {};
 
+    /**
+     * Invokes function in controller to handle root size changes.
+     * @param {Number} width 
+     * @param {Number} height 
+     */
+    const updateRootSize = (width, height) => {    
+        controller.handleRootResize(width, height);
+    };
+
     useLayoutEffect(() => {
         if (controller) {
             setRootNode(controller.ldf.containers[controller.ldf.layoutRoot]);
@@ -42,7 +51,7 @@ export const RootContainer = () => {
 
                     timerRef.current = setTimeout(() => {
                         resizingRef.current = false;
-                        console.log("Root resized to", width, height);
+                        updateRootSize(width, height);
                     }, 200);
                 }
             });

--- a/src/components/LayoutManager/Controller/LayoutController.js
+++ b/src/components/LayoutManager/Controller/LayoutController.js
@@ -95,7 +95,7 @@ export class LayoutController {
      * @param {Number} height 
      */
     handleRootResize(width, height) {
-
+        console.log("Root container resized to:", width, height);
     }
 
     /**


### PR DESCRIPTION
This PR uses the worker to recalculate the layout sizes when the root container size changes. It does this by passing the new root container size to the worker and then applying the generated transformations. 

In the next PR, when the handle bar resizes two sibling elements, both the siblings new sizes will be passed to the worker and the same process will be used to apply transformations to any of the child elements.