### PR TITLE
Prevent glitchy rendering by hiding layout until worker applies styles.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-layout-manager-dev",
-  "version": "0.0.32-dev",
+  "version": "0.0.33-dev",
   "description": "A react component to manage layout and themes in single page applications.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-layout-manager-dev",
-  "version": "0.0.30-dev",
+  "version": "0.0.32-dev",
   "description": "A react component to manage layout and themes in single page applications.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-layout-manager-dev",
-  "version": "0.0.33-dev",
+  "version": "0.0.35-dev",
   "description": "A react component to manage layout and themes in single page applications.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-layout-manager-dev",
-  "version": "0.0.35-dev",
+  "version": "0.0.36-dev",
   "description": "A react component to manage layout and themes in single page applications.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-layout-manager-dev",
-  "version": "0.0.28-dev",
+  "version": "0.0.29-dev",
   "description": "A react component to manage layout and themes in single page applications.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-layout-manager-dev",
-  "version": "0.0.29-dev",
+  "version": "0.0.30-dev",
   "description": "A react component to manage layout and themes in single page applications.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/LayoutManager/Components/RootContainer/RootContainer.jsx
+++ b/src/components/LayoutManager/Components/RootContainer/RootContainer.jsx
@@ -153,7 +153,11 @@ export const RootContainer = () => {
             onDragEnd={dragController.onDragEnd}
             onDragCancel={dragController.onDragCancel}>
             
-                {showOverlay && <div className="loading-overlay" ref={loadingOverlayRef}></div>}
+            {showOverlay && <div className="loading-overlay" ref={loadingOverlayRef}>
+                <div className="loading-bar">
+                    <div className="loading-bar-fill"></div>
+                </div>
+            </div>}
             <div className="root-container">
                 <div ref={rootRef} className="relative-container">
                     {childElements}

--- a/src/components/LayoutManager/Components/RootContainer/RootContainer.jsx
+++ b/src/components/LayoutManager/Components/RootContainer/RootContainer.jsx
@@ -36,7 +36,9 @@ export const RootContainer = () => {
     const rootContainerAPI = useRef({});
     rootContainerAPI.current = {
         hideLoadingScreen: () => {
-            setShowLoadingScreen(false);
+            if (showLoadingScreen) {
+                setShowLoadingScreen(false);
+            }
         }
     };
 

--- a/src/components/LayoutManager/Components/RootContainer/RootContainer.jsx
+++ b/src/components/LayoutManager/Components/RootContainer/RootContainer.jsx
@@ -29,10 +29,16 @@ export const RootContainer = () => {
     const rootRef = useRef(null);
     const timerRef = useRef(null);
     const resizingRef = useRef(false);
+    const loadingOverlayRef = useRef(null);
+    const [showOverlay, setShowOverlay] = useState(true);
 
     // Create the container API that will be used by the controller.
     const rootContainerAPI = useRef({});
-    rootContainerAPI.current = {};
+    rootContainerAPI.current = {
+        hideOverlay: () => {
+            setShowOverlay(false);
+        }
+    };
 
     const [childElements, setChildElements] = useState(null);
 
@@ -118,7 +124,7 @@ export const RootContainer = () => {
                 observer.disconnect();
             }
         }
-    }, [layoutController]);
+    }, [layoutController, setShowOverlay, showOverlay]);
 
     const sensors = useSensors(
         useSensor(PointerSensor, {
@@ -147,6 +153,7 @@ export const RootContainer = () => {
             onDragEnd={dragController.onDragEnd}
             onDragCancel={dragController.onDragCancel}>
             
+                {showOverlay && <div className="loading-overlay" ref={loadingOverlayRef}></div>}
             <div className="root-container">
                 <div ref={rootRef} className="relative-container">
                     {childElements}

--- a/src/components/LayoutManager/Components/RootContainer/RootContainer.jsx
+++ b/src/components/LayoutManager/Components/RootContainer/RootContainer.jsx
@@ -30,13 +30,13 @@ export const RootContainer = () => {
     const timerRef = useRef(null);
     const resizingRef = useRef(false);
     const loadingOverlayRef = useRef(null);
-    const [showOverlay, setShowOverlay] = useState(true);
+    const [showLoadingScreen, setShowLoadingScreen] = useState(true);
 
     // Create the container API that will be used by the controller.
     const rootContainerAPI = useRef({});
     rootContainerAPI.current = {
-        hideOverlay: () => {
-            setShowOverlay(false);
+        hideLoadingScreen: () => {
+            setShowLoadingScreen(false);
         }
     };
 
@@ -124,7 +124,7 @@ export const RootContainer = () => {
                 observer.disconnect();
             }
         }
-    }, [layoutController, setShowOverlay, showOverlay]);
+    }, [layoutController]);
 
     const sensors = useSensors(
         useSensor(PointerSensor, {
@@ -153,7 +153,7 @@ export const RootContainer = () => {
             onDragEnd={dragController.onDragEnd}
             onDragCancel={dragController.onDragCancel}>
             
-            {showOverlay && <div className="loading-overlay" ref={loadingOverlayRef}>
+            {showLoadingScreen && <div className="loading-overlay" ref={loadingOverlayRef}>
                 <div className="loading-bar">
                     <div className="loading-bar-fill"></div>
                 </div>

--- a/src/components/LayoutManager/Components/RootContainer/RootContainer.scss
+++ b/src/components/LayoutManager/Components/RootContainer/RootContainer.scss
@@ -13,6 +13,19 @@
     overflow: hidden;
 }
 
+.loading-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: #1a1a1a;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+}
+
 .drag-overlay {
     position: fixed;
     pointer-events: none;

--- a/src/components/LayoutManager/Components/RootContainer/RootContainer.scss
+++ b/src/components/LayoutManager/Components/RootContainer/RootContainer.scss
@@ -7,8 +7,8 @@
 
 .relative-container {
     position: relative;
-    display:flex;
-    width:100%;
+    display: flex;
+    width: 100%;
     height: 100%;
     overflow: hidden;
 }
@@ -33,30 +33,31 @@
 }
 
 .loading-bar {
-  width: 100%;
-  height: 4px;
-  background: #1a1a1a;
-  overflow: hidden;
-  position: relative;
-  border-radius: 999px;
+    width: 100%;
+    height: 4px;
+    background: #1a1a1a;
+    overflow: hidden;
+    position: relative;
+    border-radius: 999px;
 }
 
 .loading-bar-fill {
-  position: absolute;
-  top: 0;
-  left: -40%;
-  width: 40%;
-  height: 100%;
-  background: #4da3ff;
-  border-radius: 999px;
-  animation: loading-slide 1.2s infinite ease-in-out;
+    position: absolute;
+    top: 0;
+    left: -40%;
+    width: 40%;
+    height: 100%;
+    background: #4da3ff;
+    border-radius: 999px;
+    animation: loading-slide 1.2s infinite ease-in-out;
 }
 
 @keyframes loading-slide {
-  0% {
-    left: -40%;
-  }
-  100% {
-    left: 100%;
-  }
+    0% {
+        left: -40%;
+    }
+
+    100% {
+        left: 100%;
+    }
 }

--- a/src/components/LayoutManager/Components/RootContainer/RootContainer.scss
+++ b/src/components/LayoutManager/Components/RootContainer/RootContainer.scss
@@ -13,6 +13,12 @@
     overflow: hidden;
 }
 
+.drag-overlay {
+    position: fixed;
+    pointer-events: none;
+    z-index: 9999;
+}
+
 .loading-overlay {
     position: absolute;
     top: 0;
@@ -22,12 +28,35 @@
     background-color: #1a1a1a;
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: self-start;
     z-index: 9999;
 }
 
-.drag-overlay {
-    position: fixed;
-    pointer-events: none;
-    z-index: 9999;
+.loading-bar {
+  width: 100%;
+  height: 4px;
+  background: #1a1a1a;
+  overflow: hidden;
+  position: relative;
+  border-radius: 999px;
+}
+
+.loading-bar-fill {
+  position: absolute;
+  top: 0;
+  left: -40%;
+  width: 40%;
+  height: 100%;
+  background: #4da3ff;
+  border-radius: 999px;
+  animation: loading-slide 1.2s infinite ease-in-out;
+}
+
+@keyframes loading-slide {
+  0% {
+    left: -40%;
+  }
+  100% {
+    left: 100%;
+  }
 }

--- a/src/components/LayoutManager/Controller/LayoutController.js
+++ b/src/components/LayoutManager/Controller/LayoutController.js
@@ -185,8 +185,8 @@ export class LayoutController {
             case LAYOUT_WORKER_PROTOCOL.INITIALIZE_FLEXBOX:
                 transformations = event.data.data;
                 this.applyTransformations(transformations, true);
-                // TODO: Only make containers visible after the layout
-                // is applied to avoid glitchy rendering.
+                // After initial layout is applied, we can hide the loading overlay.
+                this.containers["root"].current.hideOverlay();
                 break;
             case LAYOUT_WORKER_PROTOCOL.TRANSFORMATIONS:
                 transformations = event.data.data;

--- a/src/components/LayoutManager/Controller/LayoutController.js
+++ b/src/components/LayoutManager/Controller/LayoutController.js
@@ -172,7 +172,7 @@ export class LayoutController {
             if (isInitial) {
                 this.layoutLoaded = true;
                 // After initial layout is applied, we can hide the loading screen.
-                this.containers["root"].current.hideLoadingScreen();
+                this.containers[this.ldf.layoutRoot].current.hideLoadingScreen();
             }
         });
     };

--- a/src/components/LayoutManager/Controller/LayoutController.js
+++ b/src/components/LayoutManager/Controller/LayoutController.js
@@ -171,6 +171,8 @@ export class LayoutController {
             };
             if (isInitial) {
                 this.layoutLoaded = true;
+                // After initial layout is applied, we can hide the loading screen.
+                this.containers["root"].current.hideLoadingScreen();
             }
         });
     };
@@ -185,8 +187,6 @@ export class LayoutController {
             case LAYOUT_WORKER_PROTOCOL.INITIALIZE_FLEXBOX:
                 transformations = event.data.data;
                 this.applyTransformations(transformations, true);
-                // After initial layout is applied, we can hide the loading overlay.
-                this.containers["root"].current.hideOverlay();
                 break;
             case LAYOUT_WORKER_PROTOCOL.TRANSFORMATIONS:
                 transformations = event.data.data;

--- a/src/components/LayoutManager/Controller/LayoutController.js
+++ b/src/components/LayoutManager/Controller/LayoutController.js
@@ -171,7 +171,12 @@ export class LayoutController {
             };
             if (isInitial) {
                 this.layoutLoaded = true;
-                // After initial layout is applied, we can hide the loading screen.
+                // Call root resize to apply the layout rules after initial transformations
+                // are applied, this applies the layout rules to hide the containers.
+                this.handleRootResize();
+            } else {
+                // After the initial transformations have been applied, we can hide
+                // the loading screen for the root container.
                 this.containers[this.ldf.layoutRoot].current.hideLoadingScreen();
             }
         });

--- a/src/components/LayoutManager/Controller/LayoutController.js
+++ b/src/components/LayoutManager/Controller/LayoutController.js
@@ -75,11 +75,12 @@ export class LayoutController {
         this.containers[id] = containerApi;
         this.containerRefs[id] = containerRef;
 
-        console.log(`Registered container with id: ${id} `);
+        // console.log(`Registered container with id: ${id} `);
 
         if (this.registeredContainers === this.numberOfContainers && !this.layoutLoaded) {
-            console.log("All containers registered, layout is ready.");
-            this.sendToWorker(LAYOUT_WORKER_PROTOCOL.INITIALIZE_FLEXBOX);
+            // console.log("All containers registered, layout is ready.");
+            this.sendToWorker(LAYOUT_WORKER_PROTOCOL.INITIALIZE_FLEXBOX, 
+            { sizes: this.getContainerSizes() });
         }
     }
     
@@ -91,6 +92,25 @@ export class LayoutController {
         delete this.containers[id];
     }
 
+
+    /**
+     * Retuns the sizes of the containers.
+     * @return {Object} Size of containers.
+     */
+    getContainerSizes() {
+        const containerSizes = {};
+        for (const id in this.containerRefs) {
+            if (this.containerRefs.hasOwnProperty(id)) {
+                const boundingRect = this.containerRefs[id].getBoundingClientRect();
+                containerSizes[id] = {
+                    width: boundingRect.width, 
+                    height: boundingRect.height
+                };
+            }
+        }        
+        return containerSizes;
+    }
+
     /**
      * This function is called when the root container is resized.
      * It will notify the worker to process the layout changes.
@@ -98,19 +118,9 @@ export class LayoutController {
     handleRootResize() { 
         if (!this.layoutLoaded) return;
         // console.log("Root container resized to:", width, height);
-        const sizes = {};
-        for (const id in this.containerRefs) {
-            if (this.containerRefs.hasOwnProperty(id)) {
-                const boundingRect = this.containerRefs[id].getBoundingClientRect();
-                sizes[id] = {
-                    width: boundingRect.width, 
-                    height: boundingRect.height
-                };
-            }
-        }        
         this.sendToWorker(
             LAYOUT_WORKER_PROTOCOL.APPLY_SIZES, 
-            { sizes: sizes }
+            { sizes: this.getContainerSizes() }
         );    
     }
 
@@ -170,14 +180,10 @@ export class LayoutController {
                 }
             };
             if (isInitial) {
-                this.layoutLoaded = true;
-                // Call root resize to apply the layout rules after initial transformations
-                // are applied, this applies the layout rules to hide the containers.
-                this.handleRootResize();
-            } else {
                 // After the initial transformations have been applied, we can hide
                 // the loading screen for the root container.
                 this.containers[this.ldf.layoutRoot].current.hideLoadingScreen();
+                console.log("Layout is ready, hiding loading screen.");
             }
         });
     };

--- a/src/components/LayoutManager/Controller/LayoutController.js
+++ b/src/components/LayoutManager/Controller/LayoutController.js
@@ -185,6 +185,8 @@ export class LayoutController {
             case LAYOUT_WORKER_PROTOCOL.INITIALIZE_FLEXBOX:
                 transformations = event.data.data;
                 this.applyTransformations(transformations, true);
+                // TODO: Only make containers visible after the layout
+                // is applied to avoid glitchy rendering.
                 break;
             case LAYOUT_WORKER_PROTOCOL.TRANSFORMATIONS:
                 transformations = event.data.data;

--- a/src/components/LayoutManager/Controller/Worker/LayoutEditor.js
+++ b/src/components/LayoutManager/Controller/Worker/LayoutEditor.js
@@ -17,9 +17,12 @@ export class LayoutEditor {
 
     /**
      * Initializes flexbox layout by processing LDF file.
+     * @param {Object} sizes Initial sizes of the containers.
      */
-    initializeFlexBox() {
-        this.initializeNode(this.ldf.containers[this.ldf.layoutRoot]);        
+    initializeFlexBox(sizes) {
+        this.initializeNode(this.ldf.containers[this.ldf.layoutRoot]);   
+        this.sizes = sizes; 
+        this.applyLayoutToNode(this.ldf.layoutRoot);           
         postMessage({
             type: LAYOUT_WORKER_PROTOCOL.INITIALIZE_FLEXBOX,
             data: this.transformations

--- a/src/components/LayoutManager/Controller/Worker/LayoutWorker.js
+++ b/src/components/LayoutManager/Controller/Worker/LayoutWorker.js
@@ -17,7 +17,7 @@ self.onmessage = function (e) {
                 editor = new LayoutEditor(args.ldf);
                 break;
             case LAYOUT_WORKER_PROTOCOL.INITIALIZE_FLEXBOX:
-                editor.initializeFlexBox();
+                editor.initializeFlexBox(args.sizes);
                 break;
             case LAYOUT_WORKER_PROTOCOL.APPLY_SIZES:
                 editor.applySizes(args.sizes);


### PR DESCRIPTION
This PR will add some logic to hide the layout until the worker applies the initial layout values. This will avoid glitchy rendering by displaying a loading animation until the initial layout styles and rules have been applied. 

The changes applied in this PR are:
- Adds a loading container to the root container by default
- Adds a hide loading function to the root containers api
- Once the initial styles and layout rules have been applied, the loading animation is hidden

## Validation Performed

Imported the updated library into the design workbench. Verified that the loading animation worked as expected and that the layout was not glitching when a design is loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a loading screen with animated progress bar during app startup that automatically dismisses when ready.
* **Bug Fixes / Improvements**
  * Improved startup sizing so the app layout settles correctly once initialized.
* **Chores**
  * Bumped package version to 0.0.35-dev.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->