### PR TITLE
Revert initial layout style and layout rule application order.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-layout-manager-dev",
-  "version": "0.0.36-dev",
+  "version": "0.0.38-dev",
   "description": "A react component to manage layout and themes in single page applications.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/LayoutManager/Controller/LayoutController.js
+++ b/src/components/LayoutManager/Controller/LayoutController.js
@@ -79,8 +79,7 @@ export class LayoutController {
 
         if (this.registeredContainers === this.numberOfContainers && !this.layoutLoaded) {
             // console.log("All containers registered, layout is ready.");
-            this.sendToWorker(LAYOUT_WORKER_PROTOCOL.INITIALIZE_FLEXBOX, 
-            { sizes: this.getContainerSizes() });
+            this.sendToWorker(LAYOUT_WORKER_PROTOCOL.INITIALIZE_FLEXBOX);
         }
     }
     
@@ -179,11 +178,16 @@ export class LayoutController {
                         break;
                 }
             };
-            if (isInitial) {
-                // After the initial transformations have been applied, we can hide
-                // the loading screen for the root container.
+            if (this.layoutLoaded && !isInitial) {
                 this.containers[this.ldf.layoutRoot].current.hideLoadingScreen();
                 console.log("Layout is ready, hiding loading screen.");
+            }
+            if (isInitial) {
+                // After the initial style has been applied, we request the worker
+                // to apply layout before we hide the loading screen so containers
+                // are set to correct initial state.
+                this.layoutLoaded = true;
+                this.handleRootResize();
             }
         });
     };

--- a/src/components/LayoutManager/Controller/LayoutController.js
+++ b/src/components/LayoutManager/Controller/LayoutController.js
@@ -180,7 +180,6 @@ export class LayoutController {
             };
             if (this.layoutLoaded && !isInitial) {
                 this.containers[this.ldf.layoutRoot].current.hideLoadingScreen();
-                console.log("Layout is ready, hiding loading screen.");
             }
             if (isInitial) {
                 // After the initial style has been applied, we request the worker

--- a/src/components/LayoutManager/Controller/Worker/LayoutEditor.js
+++ b/src/components/LayoutManager/Controller/Worker/LayoutEditor.js
@@ -19,10 +19,8 @@ export class LayoutEditor {
      * Initializes flexbox layout by processing LDF file.
      * @param {Object} sizes Initial sizes of the containers.
      */
-    initializeFlexBox(sizes) {
-        this.initializeNode(this.ldf.containers[this.ldf.layoutRoot]);   
-        this.sizes = sizes; 
-        this.applyLayoutToNode(this.ldf.layoutRoot);           
+    initializeFlexBox() {
+        this.initializeNode(this.ldf.containers[this.ldf.layoutRoot]);  
         postMessage({
             type: LAYOUT_WORKER_PROTOCOL.INITIALIZE_FLEXBOX,
             data: this.transformations

--- a/src/components/LayoutManager/Controller/Worker/LayoutWorker.js
+++ b/src/components/LayoutManager/Controller/Worker/LayoutWorker.js
@@ -17,7 +17,7 @@ self.onmessage = function (e) {
                 editor = new LayoutEditor(args.ldf);
                 break;
             case LAYOUT_WORKER_PROTOCOL.INITIALIZE_FLEXBOX:
-                editor.initializeFlexBox(args.sizes);
+                editor.initializeFlexBox();
                 break;
             case LAYOUT_WORKER_PROTOCOL.APPLY_SIZES:
                 editor.applySizes(args.sizes);


### PR DESCRIPTION
In the previous PR #43, at the end, I hastily introduced a change meant to apply initial layout style and to apply the layout rules in one step. However, this was a mistake because the initial layout style needs to be set for the layout rules to applied using the correct sizes. I also didn't validate the changes after I applied them before merging. So this reverts that change and goes back to doing it in two stages. 

In my refactor of this tool, I will implement this in a more efficient way. The initial styles will be applied by the components themselves and then the worker will just apply the layout rules. Once the worker applies those layout rules, the loading screen will be hidden.

## Validation Performed
In storybook and in the workbench, I changed the size of the containers to verify that they collapsed at the correct sizes. I also changed the size of the screen so that on initial load, the correct size is applied. In both cases, the UI worked as expected. I also changed the layout collapse threshold in the LDF file and confirmed that the layout reacted appropriately.


