### PR TITLE
Add functionality to enable modals to return value on close.

### DIFF
--- a/src/components/LayoutManager/Providers/ModalProvider.js
+++ b/src/components/LayoutManager/Providers/ModalProvider.js
@@ -22,6 +22,8 @@ export function ModalProvider({ children }) {
     const [modal, setModal] = useState(null);
     const downOnContentRef = useRef(false);
 
+    // TODO: Implement functionality to return values to component that created the modal.
+
     // Open a modal with the given content and title. Returns a function to close the modal.
     const openModal = useCallback(( args ) => {
         const close = () => {


### PR DESCRIPTION
This PR will modify the modal provider so that the modal will return a value to the component that created it when it is closed. I am making this change because in a lot of places, the modal simply acts as a form input and the logic that determines what to do with the information can live in the component that called it. It will clean up my component structure and simplify the implementation in many places.

In some cases, you want the modal to not act as an async input. Since this change will support both possibilities, it will let let the develop decide. I just found that in some cases, I just need a value from the user and I end up creating a new component and making it very complicated, so for the simple use cases, this change will provide the features I need. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development notes for planned modal functionality enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->